### PR TITLE
Fix typo

### DIFF
--- a/themes/theme-newspaper.css
+++ b/themes/theme-newspaper.css
@@ -193,7 +193,7 @@
 .swagger-section .swagger-ui-wrap ol li {
   padding: 5px 0px;
   font-size: 0.9em;
-  color: ##3E4049;
+  color: #3E4049;
 }
 .swagger-section .swagger-ui-wrap ol,
 .swagger-section .swagger-ui-wrap ul {


### PR DESCRIPTION
Duplicate `#` in color definition.
