### PR TITLE
Changes "max-width" from "signature-container"

### DIFF
--- a/themes/2.x/theme-flattop.css
+++ b/themes/2.x/theme-flattop.css
@@ -506,6 +506,7 @@
 }
 .swagger-section .swagger-ui-wrap .model-signature .signature-container {
   clear: both;
+  max-width: 374px;
 }
 .swagger-section .swagger-ui-wrap .body-textarea {
   width: 300px;


### PR DESCRIPTION
When there are many comments, the layout breaks beyond the "signature-container"
![github](https://user-images.githubusercontent.com/8593824/35022123-5ed78198-fb1b-11e7-99a1-c890a3a07069.png)
