### PR TITLE
Correct Text Color

### DIFF
--- a/themes/3.x/theme-material.css
+++ b/themes/3.x/theme-material.css
@@ -1287,6 +1287,10 @@
   display: flex
 }
 
+.swagger-ui .topbar .download-url-wrapper label.select-label span {
+  color: white;
+}
+
 .swagger-ui .topbar .download-url-wrapper input[type=text] {
   min-width: 350px;
   margin: 0;


### PR DESCRIPTION
The text color of the label for the API version selector within the swagger header had a bad contrast (white text with dark blue background).
It is now rectified to be white text on the dark blue background.

Before:
![image](https://user-images.githubusercontent.com/27642250/47968943-ea7fc080-e070-11e8-9b82-4b36a38d1bf2.png)

After:
![image](https://user-images.githubusercontent.com/27642250/47968947-fe2b2700-e070-11e8-8376-400df5970c55.png)

