### PR TITLE
Use HTTPS for the demo file

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -40,7 +40,7 @@
       if (url && url.length > 1) {
         url = decodeURIComponent(url[1]);
       } else {
-        url = "http://petstore.swagger.io/v2/swagger.json";
+        url = "https://petstore.swagger.io/v2/swagger.json";
       }
 
       hljs.configure({


### PR DESCRIPTION
The [demo page](https://ostranme.github.io/swagger-ui-themes/demo/) doesn't work with the current URL for the example Swagger file. The following error appears:

> Can't read from server. It may not have the appropriate access-control-origin settings.

Using the https version of the URL, the demo works as expected :)